### PR TITLE
Fixed undefined function params handling

### DIFF
--- a/lib/js/cryptex.js
+++ b/lib/js/cryptex.js
@@ -6,15 +6,11 @@
 
   exports.encrypt = function(text, key, iv, algorithm, input_encoding, output_encoding) {
     var cipher, crypted;
-    if (algorithm == null) {
-      algorithm = 'aes-256-cbc';
-    }
-    if (input_encoding == null) {
-      input_encoding = 'utf-8';
-    }
-    if (output_encoding == null) {
-      output_encoding = 'hex';
-    }
+    
+    algorithm = algorithm || 'aes-256-cbc';
+    input_encoding = input_encoding || 'utf-8';
+    output_encoding = output_encoding || 'hex';
+    
     cipher = crypto.createCipheriv(algorithm, key, iv);
     crypted = cipher.update(text, input_encoding, output_encoding);
     crypted += cipher.final(output_encoding);
@@ -23,15 +19,11 @@
 
   exports.decrypt = function(crypted, key, iv, algorithm, input_encoding, output_encoding) {
     var decipher, decrypted;
-    if (algorithm == null) {
-      algorithm = 'aes-256-cbc';
-    }
-    if (input_encoding == null) {
-      input_encoding = 'hex';
-    }
-    if (output_encoding == null) {
-      output_encoding = 'utf-8';
-    }
+    
+    algorithm = algorithm || 'aes-256-cbc';
+    input_encoding = input_encoding || 'hex';
+    output_encoding = output_encoding || 'utf-8';
+    
     decipher = crypto.createDecipheriv(algorithm, key, iv);
     decrypted = decipher.update(crypted, input_encoding, output_encoding);
     decrypted += decipher.final(output_encoding);


### PR DESCRIPTION
Sometimes it is not enough to just check if an argument is null; also, it is much nicer to use `a = a || "default value"` than `if(!a) a = "default value"`